### PR TITLE
Feature: Adding multiprocessing for spacy backbone for extractor initialization

### DIFF
--- a/elfen/extractor.py
+++ b/elfen/extractor.py
@@ -111,6 +111,16 @@ class Extractor:
         else:
             max_length = 1_000_000
 
+        if "n_process" in self.config:
+            n_process = self.config["n_process"]
+        else:
+            n_process = pl.thread_pool_size()
+
+        if "batch_size" in self.config:
+            batch_size = self.config["batch_size"]
+        else:
+            batch_size = 1
+
         # Check if the backbone is valid
         if self.config["backbone"] not in ["spacy", "stanza"]:
             raise ValueError("Backbone must be 'spacy' or 'stanza'.")
@@ -120,6 +130,8 @@ class Extractor:
                                     backbone=self.config["backbone"],
                                     lang=self.config["language"],
                                     model=self.config["model"],
+                                    batch_size=batch_size,
+                                    n_process=n_process,
                                     max_length=max_length)
         
         self.helper_cols = [

--- a/elfen/preprocess.py
+++ b/elfen/preprocess.py
@@ -29,6 +29,8 @@ def preprocess_data(data: pl.DataFrame,
                     backbone: str = 'spacy',
                     model: str = 'en_core_web_sm',
                     max_length: int = 1000000,
+                    batch_size: int = 1,
+                    n_process: int = 1,
                     **kwargs: dict[str, str],
                     ) -> pl.DataFrame:
     """
@@ -54,14 +56,26 @@ def preprocess_data(data: pl.DataFrame,
             nlp.add_pipe("syllables")
         else:
             nlp.add_pipe("syllables", after="tagger")
+
+        # Process the text data to retrieve nlp objects
+        docs = list(
+            nlp.pipe(
+                data[text_column],
+                batch_size = batch_size,
+                n_process = n_process
+            )
+        )
+        processed = pl.Series("nlp", docs)
+
     elif backbone == 'stanza':
         nlp = stanza.Pipeline(model=model,
                               processors='tokenize,pos,lemma,depparse')
+        
+        # Process the text data to retrieve nlp objects
+        processed = pl.Series("nlp", [nlp(text) for text in data[text_column]])
     else:
         raise ValueError(f"Unsupported backbone: {backbone}")
     
-    # Process the text data to retrieve nlp objects
-    processed = pl.Series("nlp", [nlp(text) for text in data[text_column]])
 
     # Create a new DataFrame to output to ensure the original data is
     # preserved unaltered


### PR DESCRIPTION
For the spacy backbone, modified the list comprehension by automatically triggering multiprocessing when initializing the extractor. As it is stated in the Elfen documentation, I made it so that polars takes by default all available CPUs.

Was not able to introduce it with the Stanza backbone, hence two different ways to obtain the "processed" variable in lines 68 and 75.

Reduces processing time. On my use case, for 10 000 news articles on a 28 CPUs machine, extractor initialization goes from more than 7 minutes to around 1 minute and 20 seconds.